### PR TITLE
Create meta/main.yml for ansible-galaxy to pull it down from requirements.yml

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,39 @@
+galaxy_info:
+  author: Mohammad Javad Naderi
+  description: Download and install assets from Github releases page.
+  company: Quera
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  license: GPL-3.0-only
+  
+  min_ansible_version: 2.1
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags:
+    - github
+    - release
+    - install
+dependencies: []


### PR DESCRIPTION
I tried to fill it out based on galaxy.yml, but according to https://stackoverflow.com/a/45432995 you could just do
```
---

galaxy_info:
```

Reproduction steps:
1) requirements.yml
```
- name: quera.github
  src: https://github.com/QueraTeam/ansible-github
```

2) ansible-galaxy install -r requirements.yml
```
Starting galaxy role install process
[WARNING]: - quera.github was NOT installed successfully: this role does not appear to have a meta/main.yml file.
ERROR! - you can use --ignore-errors to skip failed roles and finish processing the list.
```